### PR TITLE
Include data= deps for mocha_test and node_binary in runfiles.

### DIFF
--- a/node/internal/mocha_test.bzl
+++ b/node/internal/mocha_test.bzl
@@ -96,6 +96,7 @@ def mocha_test_impl(ctx):
     return struct(
         runfiles = ctx.runfiles(
             files = runfiles,
+            collect_data = True,
         ),
     )
 
@@ -110,6 +111,7 @@ mocha_test = rule(
         ),
         "data": attr.label_list(
             allow_files = True,
+            cfg = "data",
         ),
         "deps": attr.label_list(
             providers = ["node_library"],

--- a/node/internal/node_binary.bzl
+++ b/node/internal/node_binary.bzl
@@ -76,6 +76,7 @@ def node_binary_impl(ctx):
     return struct(
         runfiles = ctx.runfiles(
             files = runfiles,
+            collect_data = True,
         ),
     )
 
@@ -89,6 +90,7 @@ node_binary = rule(
         ),
         "data": attr.label_list(
             allow_files = True,
+            cfg = "data",
         ),
         "deps": attr.label_list(
             providers = ["node_library"],


### PR DESCRIPTION
Without this, changes to data dependencies will not invalidate cached
test results-- which is bad for mocha_test comparing against external
test artifacts!