### PR TITLE
Make the toolchain version customizable

### DIFF
--- a/node/internal/node_repositories.bzl
+++ b/node/internal/node_repositories.bzl
@@ -55,23 +55,24 @@ _node_toolchain = repository_rule(
     },
 )
 
-def node_repositories():
-
+def node_repositories(version="6.6.0",
+                      linux_sha256="c22ab0dfa9d0b8d9de02ef7c0d860298a5d1bf6cae7413fb18b99e8a3d25648a",
+                      darwin_sha256="c8d1fe38eb794ca46aacf6c8e90676eec7a8aeec83b4b09f57ce503509e7a19f"):
     native.new_http_archive(
         name = "nodejs_linux_amd64",
-        url = "https://nodejs.org/dist/v6.6.0/node-v6.6.0-linux-x64.tar.gz",
+        url = "https://nodejs.org/dist/v{version}/node-v{version}-linux-x64.tar.gz".format(version=version),
         type = "tar.gz",
-        strip_prefix = "node-v6.6.0-linux-x64",
-        sha256 = "c22ab0dfa9d0b8d9de02ef7c0d860298a5d1bf6cae7413fb18b99e8a3d25648a",
+        strip_prefix = "node-v{version}-linux-x64".format(version=version),
+        sha256 = linux_sha256,
         build_file_content = "",
     )
 
     native.new_http_archive(
         name = "nodejs_darwin_amd64",
-        url = "https://nodejs.org/dist/v6.6.0/node-v6.6.0-darwin-x64.tar.gz",
+        url = "https://nodejs.org/dist/v{version}/node-v{version}-darwin-x64.tar.gz".format(version=version),
         type = "tar.gz",
-        strip_prefix = "node-v6.6.0-darwin-x64",
-        sha256 = "c8d1fe38eb794ca46aacf6c8e90676eec7a8aeec83b4b09f57ce503509e7a19f",
+        strip_prefix = "node-v{version}-darwin-x64".format(version=version),
+        sha256 = darwin_sha256,
         build_file_content = "",
     )
 


### PR DESCRIPTION
## What does this PR do?

This adds parameters to the `node_repositories` workspace macro.

## Why?

This allows projects to pull in the version of node that they need in
WORKSPACE files, without tying themselves to a particular update
cadence. Also, it tidies up the macro a little - anyone bumping the version number now has to make only one edit, plus the SHA256s.

I've adjusted our internal repo to use this change, and it works quite well for our usage of node 7.10.0, like so:
``` py
load("@org_pubref_rules_node//node:rules.bzl", "node_repositories")
node_repositories(
    version="7.10.0",
    linux_sha256="9da0e99091897795491d21d58c40186f75ca7bf505d145d1a2e558f8c754a81b",
    darwin_sha256="7ec21c06b80924893fff3eba242cbe5c8b1aadcdd6be39707b28dd3cfe8e558f",
)
```

Please let me know if there's anything you want changed - I'd love to use the official repo, so am happy to make any change that gets this in here (: