### PR TITLE
Fix emit duplicate sh_binary rules by parse_yarn_lock.js

### DIFF
--- a/node/internal/node_binary.bzl
+++ b/node/internal/node_binary.bzl
@@ -28,7 +28,7 @@ def _copy_module(ctx, output_dir, module):
         dst_filename = _get_filename_relative_to_module(module, src)
         dst = ctx.new_file('%s/node_modules/%s' % (output_dir, dst_filename))
         outputs.append(dst)
-        script_lines.append('cp %s %s' % (src.path, dst.path))
+        script_lines.append("cp '%s' '%s'" % (src.path, dst.path))
 
     ctx.file_action(
         output = script_file,

--- a/node/internal/node_module.bzl
+++ b/node/internal/node_module.bzl
@@ -108,7 +108,7 @@ def _copy_file(ctx, src, dst):
         mnemonic = "CopyFileToNodeModule",
         inputs = [src],
         outputs = [dst],
-        command = "cp %s %s" % (src.path, dst.path),
+        command = "cp '%s' '%s'" % (src.path, dst.path),
     )
     return dst
 

--- a/node/internal/parse_yarn_lock.js
+++ b/node/internal/parse_yarn_lock.js
@@ -21,7 +21,7 @@ entries.forEach(entry => printNodeModule(entry));
 
 printNodeModules(cache);
 
-entries.forEach(entry => parsePackageJson(entry));
+cache.forEach(entry => parsePackageJson(entry));
 
 print("");
 print("# EOF");


### PR DESCRIPTION
Previously iteration over the entries map was done rather than
the de-duplicated cache map.

This PR also fixes a bug where filenames with '$' were not
being copied correctly.