### PR TITLE
Add .json file extension to avoid files named package.js

### DIFF
--- a/node/internal/parse_yarn_lock.js
+++ b/node/internal/parse_yarn_lock.js
@@ -101,7 +101,7 @@ function printNodeModules(map) {
 }
 
 function parsePackageJson(entry) {
-  const pkg = require(`./node_modules/${entry.name}/package`);
+  const pkg = require(`./node_modules/${entry.name}/package.json`);
   if (Array.isArray(pkg.bin)) {
     // should not happen: throw new Error('Hmm, I didn\'t realize pkg.bin could be an array.');
   } else if (typeof pkg.bin === 'string') {


### PR DESCRIPTION
The package [js-base64](https://www.npmjs.com/package/js-base64) was problematic because it contains a file named `package.js`.