### PR TITLE
fix: inner package test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,4 @@ test_all:
 	(cd tests/namespace && bazel test //:question_test)
 	(cd tests/typescript && bazel test //:typescript_test)
 	(cd tests/mocha && bazel test //:test)
+	(cd tests/mocha && bazel test //tests:test)

--- a/node/internal/mocha_test.bzl
+++ b/node/internal/mocha_test.bzl
@@ -4,8 +4,11 @@ load("//node:internal/node_binary.bzl", "copy_modules", "binary_attrs")
 
 def _create_launcher(ctx, output_dir, node, mocha):
     entry_module = ctx.attr.entrypoint.node_module
+    # if package is under root
     entrypoint = '%s_test/node_modules/%s' % (ctx.label.name, entry_module.name)
-
+    # if test is under inner package
+    if ctx.label.package:
+        entrypoint = '%s/%s' % (ctx.label.package, entrypoint)
     cmd = [
         node.short_path,
     ] + ctx.attr.node_args + [
@@ -21,7 +24,6 @@ def _create_launcher(ctx, output_dir, node, mocha):
         'set -e',
         ' '.join(cmd)
     ]
-
     ctx.file_action(
         output = ctx.outputs.executable,
         executable = True,

--- a/tests/mocha/tests/BUILD
+++ b/tests/mocha/tests/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@org_pubref_rules_node//node:rules.bzl", "node_binary", "node_module", "mocha_test")
+
+mocha_test(
+    name = "test",
+    main = "test.js",
+)
+
+# Can one test a bazel test?  I'm getting 'fork: Resource temporarily unavailable' when I try to run this.
+# sh_test(
+#     name = "test_test",
+#     size = "small",
+#     srcs = ["test.sh"],
+#     data = [":test"],
+# )

--- a/tests/mocha/tests/test.js
+++ b/tests/mocha/tests/test.js
@@ -1,0 +1,9 @@
+var assert = require('assert');
+
+describe('Array', function() {
+  describe('#indexOf()', function() {
+    it('should return -1 when the value is not present', function() {
+      assert.equal(-1, [1,2,3].indexOf(4));
+    });
+  });
+});


### PR DESCRIPTION
fix mocha test when package is in the nest folder