### PR TITLE
Specify parsing package.json when walking node_modules

### DIFF
--- a/node/internal/parse_yarn_lock.js
+++ b/node/internal/parse_yarn_lock.js
@@ -354,7 +354,7 @@ function printNodeBinary(module, key, path) {
  * package json and return it as an object.
  */
 function parseNodeModulePackageJson(name) {
-  const module = require(`../node_modules/${name}/package`);
+  const module = require(`../node_modules/${name}/package.json`);
 
   // Take this opportunity to cleanup the module.bin entries
   // into a new Map called 'executables'


### PR DESCRIPTION
Provide the concrete filename to avoid accidentally loading
'package.js' or similarly-named files.

Fixes #43.