### PR TITLE
Add tests for polymer-cli binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/tests/*/bazel-*

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ test_typescript:
 test_webpack:
 	(cd tests/webpack && bazel test //...)
 
+test_polymer-cli:
+	(cd tests/polymer-cli && bazel test //...)
+
 test_mocha:
 	(cd tests/mocha && bazel test //...)
 
-test_all: test_helloworld test_lyrics test_express test_namespace test_typescript test_webpack test_mocha
+test_all: test_helloworld test_lyrics test_express test_namespace test_typescript test_webpack test_polymer-cli test_mocha

--- a/node/internal/parse_yarn_lock.js
+++ b/node/internal/parse_yarn_lock.js
@@ -208,9 +208,10 @@ function breakCircularDependencies(modules) {
           }
         });
 
-        // Each entry in the cluster must have no other outgoing
-        // dependencies
-        entry.deps = new Set();
+        // Each entry in the cluster must have no connections to other
+        // dependencies in the cluster, or on the cluster pseudo-dep
+        pseudo.deps.forEach(circ => entry.deps.delete(circ));
+        entry.deps.delete(pseudo);
       });
 
       // Store this new pseudo-module in the modules list

--- a/node/internal/parse_yarn_lock.js
+++ b/node/internal/parse_yarn_lock.js
@@ -288,7 +288,11 @@ function printNodeModule(module) {
     
     print(`    version = "${module.version}",`);
     print(`    package_json = "node_modules/${module.name}/package.json",`);
-    print(`    srcs = glob(["node_modules/${module.name}/**/*"], exclude = ["node_modules/${module.name}/package.json"]),`);
+    // Exclude filenames with spaces: Bazel can't cope with them (we just have to hope they aren't needed later...)
+    print(`    srcs = glob(["node_modules/${module.name}/**/*"], exclude = [
+		"node_modules/${module.name}/package.json",
+		"**/* *",
+	]),`);
     if (url) {
       print(`    url = "${url}",`);
     }

--- a/node/internal/parse_yarn_lock.js
+++ b/node/internal/parse_yarn_lock.js
@@ -284,14 +284,15 @@ function printNodeModule(module) {
   print(``);
   printJson(module);
   print(`node_module(`);
-  print(`    name = "${module.name}",`);
+  print(`    name = "${module.yarn ? module.yarn.label : module.name}",`);
 
   // SCC pseudomodule wont have 'yarn' property
   if (module.yarn) {
     const url = module.yarn.url || module.url;
     const sha1 = module.yarn.sha1;
     const executables = module.executables;
-    
+
+    print(`    module_name = "${module.name}",`);
     print(`    version = "${module.version}",`);
     print(`    package_json = "node_modules/${module.name}/package.json",`);
     // Exclude filenames with spaces: Bazel can't cope with them (we just have to hope they aren't needed later...)
@@ -313,12 +314,12 @@ function printNodeModule(module) {
       }
       print(`    },`);
     }
-
   }
+
   if (deps && deps.size) {
     print(`    deps = [`);
     deps.forEach(dep => {
-      print(`        ":${dep.name}",`);
+      print(`        ":${dep.yarn ? dep.yarn.label : dep.name}",`);
     });
     print(`    ],`);
   }
@@ -337,7 +338,7 @@ function printNodeModuleAll(modules) {
   print(`    name = "_all_",`);
   print(`    deps = [`);
   modules.forEach(module => {
-    print(`        ":${module.name}",`);
+    print(`        ":${module.yarn ? module.yarn.label : module.name}",`);
   });
   print(`    ],`);
   print(`)`);

--- a/tests/polymer-cli/BUILD
+++ b/tests/polymer-cli/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+sh_test(
+    name = "polymer-cli_bin_test",
+    size = "small",
+    srcs = ["polymer-cli_bin_test.sh"],
+	data = ["@yarn_modules//:polymer-cli_polymer_bin"],
+)
+

--- a/tests/polymer-cli/README.md
+++ b/tests/polymer-cli/README.md
@@ -1,0 +1,17 @@
+# Polymer CLI Example
+
+This folder demonstrates that the generated `BUILD` file for
+`@yarn_modules` contains a `node_binary` rule for the polymer-cli module
+executable.  It tests that the target is callable and that the help
+message is output.
+
+Polymer CLI is a fairly complex dependency that contains @-scoped dependencies
+and complex cyclic dependencies.
+
+```sh
+# Should be able to run polymer-cli directly
+$ bazel build @yarn_modules//:polymer-cli_polymer_bin -- --help
+
+# Should be able to invoke polymer-cli as standalone script 
+$ ./bazel-bin/external/yarn_modules/polymer-cli_polymer_bin --help
+```

--- a/tests/polymer-cli/WORKSPACE
+++ b/tests/polymer-cli/WORKSPACE
@@ -1,0 +1,17 @@
+workspace(name = "org_pubref_rules_node_polymer_test")
+
+local_repository(
+    name = "org_pubref_rules_node",
+    path = "../..",
+)
+
+load("@org_pubref_rules_node//node:rules.bzl", "node_repositories", "yarn_modules")
+
+node_repositories()
+
+yarn_modules(
+    name = "yarn_modules",
+    deps = {
+        "polymer-cli": "1.5.7",
+    },
+)

--- a/tests/polymer-cli/polymer-cli_bin_test.sh
+++ b/tests/polymer-cli/polymer-cli_bin_test.sh
@@ -1,0 +1,7 @@
+set -e
+
+if (./external/yarn_modules/polymer-cli_polymer_bin --help &) | grep -qF '/__\/   /__\/  \/__\  The multi-tool for Polymer projects'; then
+    echo "PASS"
+else
+    exit 1
+fi


### PR DESCRIPTION
Attempting to build genrules based on a node_binary for [polymer-cli](https://github.com/Polymer/polymer-cli) results in errors at several points - initially related to @-scoped module names, but also the TARGET_PATH determination for the binary itself (exposed when a WORKSPACE name is set, and the magic `__main__` path is no longer present).

This branch introduces a (failing) test using polymer-cli, similar to the webpack test, and then attempts to resolve the issues.