### PR TITLE
node_proto_module macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,7 @@ test_webpack:
 test_mocha:
 	(cd tests/mocha && bazel test //...)
 
-test_all: test_helloworld test_lyrics test_express test_namespace test_typescript test_webpack test_mocha
+test_protobuf:
+	(cd tests/protobuf && bazel test //...)
+
+test_all: test_helloworld test_lyrics test_express test_namespace test_typescript test_webpack test_mocha test_protobuf

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | [node_binary](#node_binary) | Run a node module. |
 | [node_test](#node_test) | Run a node binary as a bazel test. |
 | [mocha_test](#mocha_test) | Run a mocha test script. |
+| [node_proto_module](#node_proto_module) | Define a node module by generating JavaScript code from a set of .proto files.
 
 <table><tr>
 <td><img src="https://www.kernel.org/theme/images/logos/tux.png" height="48"/></td>
@@ -372,6 +373,47 @@ mocha_test(
     main = "test.js",
 )
 ```
+
+## node_proto_library
+
+Define a node module by generating JavaScript code from a set of .proto files given in `srcs`. One 
+file is generated for each `src` in the `srcs` list as `src_pb.js`. The output is a 
+[node_module](#node_module) with the generated files in the root of the module.
+
+> Note: The node_proto_library rule depends on `@com_google_protobuf//:protoc` and
+> `@protobuf_modules//:_all_`, so you'll need to add these dependencies to your `WORKSPACE` file:
+
+```python
+http_archive(
+    name = "com_google_protobuf",
+    urls = ["https://github.com/google/protobuf/archive/v3.4.0.zip"],
+    strip_prefix = "protobuf-3.4.0",
+    sha256 = "542703acadc3f690d998f4641e1b988f15ba57ebca05fdfb1cd9095bec007948"
+)
+
+yarn_modules(
+    name = "protobuf_modules",
+    deps = {
+        "mocha": "3.4.0"
+    }
+)
+```
+
+```python
+node_proto_library(
+    name = "foo",
+    srcs = ["foo.proto"]
+)
+```
+
+#### Options
+
+|  | Type | Name | Default | Description |
+| ---: | :--- | :--- | :--- | :--- |
+| optional | `boolean` | `binary` | `True` | Set `--js_out=binary` for `protoc`
+| optional | `boolean` | `descriptor` | `False` | Write out the protobuf descriptor file as `name.descriptor`
+| optional | `Label` | `protobuf_modules` | `@protobuf_modules//:_all_` | [yarn_modules](#yarn_modules) containing the protobuf dependency `"google-protobuf": "3.4.0"`
+| optional | `Label` | `protocbin` | `@com_google_protobuf//:protoc` | Protobuf `protoc` compiler
 
 ## Conclusion
 

--- a/node/internal/node_proto_module.bzl
+++ b/node/internal/node_proto_module.bzl
@@ -1,0 +1,48 @@
+load("//node:internal/node_module.bzl", "node_module")
+
+_protocbin = Label("@com_google_protobuf//:protoc")
+_protobuf_modules = Label("@protobuf_modules//:_all_")
+
+def node_proto_module(name,
+                      srcs,
+                      binary = True,
+                      descriptor = False,
+                      protobuf_modules = _protobuf_modules,
+                      protocbin = _protocbin,
+                      **kwargs):
+    outs = [src.split('.')[0] + "_pb.js" for src in srcs]
+
+    js_out_options = ["import_style=commonjs"]
+
+    if binary:
+        js_out_options += ["binary"]
+
+    cmd = ["$(location %s)" % protocbin]
+    cmd += ["--js_out=%s:$(GENDIR)" % ",".join(js_out_options)]
+
+    if descriptor:
+        cmd += ["--descriptor_set_out=$(@D)/%s.descriptor" % name]
+        outs += [name + ".descriptor"]
+
+    cmd += ["$(location " +src + ")" for src in srcs]
+
+    native.genrule(
+        name = name + "_gen",
+        cmd = " ".join(cmd),
+        srcs = srcs,
+        message = "Generating NodeJS Protocol Buffer file(s)...",
+        outs = outs,
+        tools = [protocbin],
+        visibility = ["//visibility:private"]
+    )
+
+    node_module(
+        name = name,
+        srcs = outs,
+        deps = [protobuf_modules],
+        executables = None,
+        index = None,
+        main = None,
+        package_json = None,
+        **kwargs
+    )

--- a/node/rules.bzl
+++ b/node/rules.bzl
@@ -6,4 +6,4 @@ load("//node:internal/node_binary.bzl", "node_binary")
 load("//node:internal/node_binary.bzl", "node_test")
 load("//node:internal/node_bundle.bzl", "node_bundle")
 load("//node:internal/mocha_test.bzl", "mocha_test")
-                                        
+load("//node:internal/node_proto_module.bzl", "node_proto_module")

--- a/tests/protobuf/BUILD
+++ b/tests/protobuf/BUILD
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@org_pubref_rules_node//node:rules.bzl", "mocha_test", "node_proto_module")
+
+node_proto_module(
+    name = "proto-test-module",
+    srcs = ["test.proto"]
+)
+
+mocha_test(
+    name = "proto-test",
+    srcs = ["test.js"],
+    deps = [":proto-test-module"],
+    main = "test.js"
+)

--- a/tests/protobuf/WORKSPACE
+++ b/tests/protobuf/WORKSPACE
@@ -1,0 +1,29 @@
+local_repository(
+    name = "org_pubref_rules_node",
+    path = "../..",
+)
+
+load("@org_pubref_rules_node//node:rules.bzl", "node_repositories", "yarn_modules")
+
+node_repositories()
+
+yarn_modules(
+    name = "protobuf_modules",
+    deps = {
+        "google-protobuf": "3.4.0"
+    }
+)
+
+yarn_modules(
+    name = "mocha_modules",
+    deps = {
+        "mocha": "4.0.1"
+    }
+)
+
+http_archive(
+    name = "com_google_protobuf",
+    urls = ["https://github.com/google/protobuf/archive/v3.4.0.zip"],
+    strip_prefix = "protobuf-3.4.0",
+    sha256 = "542703acadc3f690d998f4641e1b988f15ba57ebca05fdfb1cd9095bec007948"
+)

--- a/tests/protobuf/test.js
+++ b/tests/protobuf/test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert');
+
+const testproto = require('proto-test-module/test_pb');
+
+describe('Protobuf', function () {
+
+  var msg;
+  var code;
+
+  var bytes;
+
+  before(function () {
+    msg = 'TESTING';
+    code = 1000;
+  });
+
+  it('should serialize successfully', function () {
+    var msg1 = new testproto.TestMessage();
+    msg1.setMsg(msg);
+    msg1.setCode(code);
+
+    bytes = msg1.serializeBinary();
+  });
+
+  it('should deserialize successfully', function () {
+    var msg2 = testproto.TestMessage.deserializeBinary(bytes);
+    assert.equal(msg, msg2.getMsg());
+    assert.equal(code, msg2.getCode());
+  });
+});

--- a/tests/protobuf/test.proto
+++ b/tests/protobuf/test.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package testproto;
+
+message TestMessage {
+  string msg = 1;
+  int32 code = 2;
+}


### PR DESCRIPTION
Add a macro to generate CommonJS style JavaScript code from `.proto` files, and package it as a `node_module`.

This macro makes it easy to generate protobuf code for node modules at build time instead of bundling statically generated files or writing custom rules.