### PR TITLE
Fix polymer-cli test by specifying update-notifier version

### DIFF
--- a/tests/polymer-cli/WORKSPACE
+++ b/tests/polymer-cli/WORKSPACE
@@ -13,5 +13,6 @@ yarn_modules(
     name = "yarn_modules",
     deps = {
         "polymer-cli": "1.5.7",
+        "update-notifier": "1.0.3",
     },
 )


### PR DESCRIPTION
Fix for issue mentioned in #48.

I was expecting `resolutions` to work but it seemed that I had to fix the transitive version through the `deps` attribute instead. I suspect that generally it is more correct to pin all resolutions rather than just some - in the same manner as a `yarn.lock` file - but this at least gets the build unbroken.