### PR TITLE
Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,12 @@
+test_task:
+  container:
+    matrix:
+      image: cirrusci/bazel:0.7.0
+      image: cirrusci/bazel:0.6.1
+      image: cirrusci/bazel:0.5.4
+      image: cirrusci/bazel:0.5.3
+    cpu: 4
+    memory: 12G
+  configure_script: |
+    - echo "buils --spawn_strategy=remote --genrule_strategy=remote --remote_rest_cache=http://$CIRRUS_HTTP_CACHE_HOST" | sudo tee /etc/bazel.bazelrc
+  test_all_script: make test_all

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ osx_image: xcode8
 language: java
 
 os:
-  - linux
   - osx
 
 env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <td>Yarn</td>
 </tr></table>
 
-# `rules_node` [![Build Status](https://travis-ci.org/pubref/rules_node.svg?branch=master)](https://travis-ci.org/pubref/rules_node)
+# `rules_node` [![Build Status](https://cirrus-ci.com/github/pubref/rules_node.svg?branch=master)](https://cirrus-ci.com/github/pubref/rules_node) [![Build Status](https://travis-ci.org/pubref/rules_node.svg?branch=master)](https://travis-ci.org/pubref/rules_node)
 
 # Rules
 


### PR DESCRIPTION
Configured as described in https://cirrus-ci.org/examples/#bazel

Cirrus CI has first class support for build systems like Bazel by providing built-in HTTP Cache. This change enables Cirrus CI which is 3 times faster.

![image](https://user-images.githubusercontent.com/989066/35871943-8873ea82-0b33-11e8-8746-66dcc9c512ea.png)

Feel free to close the PR if you are not going to change the current CI situation. In case of merging please don't forget to [install Cirrus CI](https://github.com/apps/cirrus-ci) on the repository before merging.