### PR TITLE
Fixes pubref/rules_node#63

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ test_express:
 test_namespace:
 	(cd tests/namespace && bazel test //...)
 
+test_rollup:
+	(cd tests/rollup && bazel test //...)
+
 test_typescript:
 	(cd tests/typescript && bazel test //...)
 
@@ -22,4 +25,4 @@ test_polymer-cli:
 test_mocha:
 	(cd tests/mocha && bazel test //...)
 
-test_all: test_helloworld test_lyrics test_express test_namespace test_typescript test_webpack test_polymer-cli test_mocha
+test_all: test_helloworld test_lyrics test_express test_namespace test_typescript test_webpack test_polymer-cli test_mocha test_rollup

--- a/node/internal/node_binary.bzl
+++ b/node/internal/node_binary.bzl
@@ -88,6 +88,7 @@ def create_launcher(ctx, output_dir, node, manifest):
 
         '# Modify path such that embedded scripts with /usr/bin/env node shebangs',
         '# resolve to the bundled node executable',
+        'export NODE_PATH="${TARGET_PATH}/node_modules"',
         'export PATH="${TARGET_PATH}:$PATH"',
 
         ' '.join(cmd)

--- a/tests/rollup/BUILD
+++ b/tests/rollup/BUILD
@@ -1,0 +1,49 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@org_pubref_rules_node//node:rules.bzl", "node_binary")
+load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
+
+#
+# Rollup bundling
+#
+node_binary(
+    name = "rollup_with_plugins",
+    entrypoint = "@yarn_modules//:rollup",
+    executable = "rollup",
+    deps = ["@yarn_modules//:_all_"],
+)
+
+genrule(
+    name = "genrule_target",
+    tools = [
+        ":rollup_with_plugins",
+        ":rollup.config.js",
+    ],
+    srcs = [
+        "es6_src.js",
+    ],
+    outs = [
+        "genrule_target.js",
+    ],
+    executable = 1,
+    cmd = " ".join([
+        "$(location :rollup_with_plugins)",
+        "-c $(location :rollup.config.js)",
+        "-i $(location :es6_src.js)",
+        "-f cjs",
+        "-o $(location :genrule_target.js)"
+    ])
+)
+
+
+file_test(
+    name = "test",
+    size = "small",
+    file = ":genrule_target",
+    content = """'use strict';
+
+function es6_src () { return "if I build, then all's good"; }
+
+module.exports = es6_src;
+"""
+)

--- a/tests/rollup/README.md
+++ b/tests/rollup/README.md
@@ -1,0 +1,8 @@
+# Rollup Example
+
+This test verifies that `NODE_PATH` is set to the node_modules directory while executing `node_binary` rules. The test uses a [rollup configuration file](https://rollupjs.org/guide/en#configuration-files) supplied to a genrule that includes `node_module` depenendencies supplied to a `node_binary` target.
+
+```
+$ bazel test :test
+```
+

--- a/tests/rollup/WORKSPACE
+++ b/tests/rollup/WORKSPACE
@@ -1,0 +1,18 @@
+local_repository(
+    name = "org_pubref_rules_node",
+    path = "../..",
+)
+
+load("@org_pubref_rules_node//node:rules.bzl", "node_repositories", "yarn_modules")
+
+node_repositories()
+
+yarn_modules(
+    name = "yarn_modules",
+    deps = {
+        "rollup": "0.56.5",
+        # rollup-plugin-buble is simply an external node module to the
+        # rollup binary that will be required at runtime.
+        "rollup-plugin-buble": "0.19.2",
+    }
+)

--- a/tests/rollup/es6_src.js
+++ b/tests/rollup/es6_src.js
@@ -1,0 +1,1 @@
+export default () => "if I build, then all's good";

--- a/tests/rollup/rollup.config.js
+++ b/tests/rollup/rollup.config.js
@@ -1,0 +1,7 @@
+import buble from 'rollup-plugin-buble';
+
+export default {
+  plugins: [
+    buble()
+  ]
+};


### PR DESCRIPTION
adds NODE_PATH to node_binary to allow node_modules in the node_binary deps to be included at runtime. see tests/rollup for a repro.