### PR TITLE
Fixes pubref/rules_node#65

### DIFF
--- a/node/internal/parse_yarn_lock.js
+++ b/node/internal/parse_yarn_lock.js
@@ -76,8 +76,8 @@ function isPackage(p, s, f) {
 }
 
 /**
- * Given a list of yarn entries and a target module, find an exact
- * match by name and version.
+ * Given a list of yarn entries and a target module, find an exact match by name
+ * and version.
  */
 function findMatchingYarnEntryByNameAndVersion(entries, module) {
   for (let i = 0; i < entries.length; i++) {
@@ -237,9 +237,13 @@ function makeYarnEntry(key, entry) {
  * Parse a yarn name into something that will be agreeable to bazel.
  */
 function parseName(key, entry) {
-  // can be 'foo@1.0.0' or something like '@types/foo@1.0.0'
-  const at = key.lastIndexOf('@');
   entry.id = key;
+
+  // can be 'foo@1.0.0' or something like '@types/foo@1.0.0'
+  // or even something like @types/foo@https://git@github.com/pkg#mod.
+  // TODO: Regexes would be better here to support more package.json dependency
+  // formats: https://docs.npmjs.com/files/package.json#dependencies
+  const at = key.indexOf("@", 1);
   entry.name = key.slice(0, at);
 
   const label = entry.name.replace('@', 'at-');

--- a/tests/express/README.md
+++ b/tests/express/README.md
@@ -3,6 +3,7 @@
 This folder demonstrates the use of node_binary with a node modules
 dependency that has other modular dependencies.  In this case, we're
 using the `yarn_modules.package_json` attribute rather than the `deps`
-attribute to specify the dependency on express.  We're also using the
-`@yarn_modules//:_all_` pseudo-module target to pull in all the module
-dependencies.
+attribute to specify the dependency on express. Another dependency on
+express-sessoin is added to package.json using a github npm URL. We're
+also using the `@yarn_modules//:_all_` pseudo-module target to pull in
+all the module dependencies.

--- a/tests/express/WORKSPACE
+++ b/tests/express/WORKSPACE
@@ -10,4 +10,6 @@ node_repositories()
 yarn_modules(
     name = "yarn_modules",
     package_json = "//:package.json",
+    # Allows yarn to unpack the express-session git repo in package.json
+    install_tools = ["git"],
 )

--- a/tests/express/package.json
+++ b/tests/express/package.json
@@ -2,6 +2,7 @@
     "name": "server",
     "version": "1.0.0",
     "dependencies": {
-        "express": "4.15.4"
+        "express": "4.15.4",
+        "express-session": "git+https://git@github.com/expressjs/session#v1.15.6"
     }
 }

--- a/tests/express/server.js
+++ b/tests/express/server.js
@@ -1,6 +1,10 @@
 const express = require("express");
+const session = require('express-session');
 
 const app = express();
+app.use(session({
+  secret: 'super secret session'
+}));
 
 app.get('/', (req, res) => {
   res.send('Hello World!');


### PR DESCRIPTION
parse_yarn_lock.js: adds a hack for handling npm version URLs and extends the express test to cover this case.